### PR TITLE
Fix invalid docker tag

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -13,7 +13,7 @@ P4D_GRACE=30
 
 # Swarm Configuration
 
-SWARM_VER="latest"
+SWARM_VER=latest
 
 SWARM_USER=swarm
 SWARM_PASSWD=HelixDockerBay94


### PR DESCRIPTION
Prior to this change, the default docker-compose would try to tag the swarm container as `perforce/helix-swarm:"latest"` which is not a valid tag. This lead to a very cryptic error:
```
ERROR: invalid reference format
```
